### PR TITLE
Enforce a single RequestHandler, not an array of RequestHandler

### DIFF
--- a/swagger-express-middleware.d.ts
+++ b/swagger-express-middleware.d.ts
@@ -48,13 +48,13 @@ declare namespace middleware {
     /** This method creates a new Mock middleware instance. */
     mock: interfaces.Mock;
     /** This method creates a new Metadata middleware instance. */
-    metadata(router?: interfaces.Router): express.RequestHandler[];
+    metadata(router?: interfaces.Router): express.RequestHandler;
     /** This method creates a new Parse Request middleware instance. */
     parseRequest: interfaces.ParseRequest;
     /** This method creates a new Validate Request middleware instance. */
-    validateRequest(router?: interfaces.Router): express.RequestHandler[];
+    validateRequest(router?: interfaces.Router): express.RequestHandler;
     /** This method creates a new CORS middleware instance. */
-    CORS(): express.RequestHandler[];
+    CORS(): express.RequestHandler;
     /** This method creates a new Files middleware instance. */
     files: interfaces.Files;
   }
@@ -63,14 +63,14 @@ declare namespace middleware {
     type Router = express.Router|express.Application;
 
     export interface Mock {
-      (router?: Router, dataStore?: DataStore): express.RequestHandler[];
-      (dataStore?: DataStore): express.RequestHandler[];
+      (router?: Router, dataStore?: DataStore): express.RequestHandler;
+      (dataStore?: DataStore): express.RequestHandler;
     }
 
     export interface ParseRequest {
       //TODO: options should be typed
-      (router?: Router|ExpressRouteOptions, options?: any): express.RequestHandler[];
-      (options?: any): express.RequestHandler[];
+      (router?: Router|ExpressRouteOptions, options?: any): express.RequestHandler;
+      (options?: any): express.RequestHandler;
     }
 
     export interface ExpressRouteOptions {
@@ -201,8 +201,8 @@ declare namespace middleware {
     }
 
     export interface Files {
-      (router?: Router|ExpressRouteOptions, options?: FilesOptions): express.RequestHandler[];
-      (options?: FilesOptions): express.RequestHandler[];
+      (router?: Router|ExpressRouteOptions, options?: FilesOptions): express.RequestHandler;
+      (options?: FilesOptions): express.RequestHandler;
     }
 
     export interface FilesOptions {

--- a/test/swagger-express-middleware-test.ts
+++ b/test/swagger-express-middleware-test.ts
@@ -11,12 +11,12 @@ let app = express();
 
 middleware(path.join(__dirname, 'PetStore.yaml'), app, (err, middleware) => {
   app.use(
-    ...middleware.metadata(),
-    ...middleware.CORS(),
-    ...middleware.files(),
-    ...middleware.parseRequest(),
-    ...middleware.validateRequest(),
-    ...middleware.mock()
+    middleware.metadata(),
+    middleware.CORS(),
+    middleware.files(),
+    middleware.parseRequest(),
+    middleware.validateRequest(),
+    middleware.mock()
   );
 
   app.listen(8000, function() {
@@ -45,8 +45,8 @@ middlewareInstance.init(path.join(__dirname, 'PetStore.yaml'), err => {
   app.enable('case sensitive routing');
   app.enable('strict routing');
 
-  app.use(...middlewareInstance.metadata());
-  app.use(...middlewareInstance.files(
+  app.use(middlewareInstance.metadata());
+  app.use(middlewareInstance.files(
     {
       // Override the Express App's case-sensitive and strict-routing settings
       // for the Files middleware.
@@ -62,7 +62,7 @@ middlewareInstance.init(path.join(__dirname, 'PetStore.yaml'), err => {
     }
   ));
 
-  app.use(...middlewareInstance.parseRequest(
+  app.use(middlewareInstance.parseRequest(
     {
       // Configure the cookie parser to use secure cookies
       cookie: {
@@ -83,8 +83,8 @@ middlewareInstance.init(path.join(__dirname, 'PetStore.yaml'), err => {
 
   // These two middleware don't have any options (yet)
   app.use(
-    ...middlewareInstance.CORS(),
-    ...middlewareInstance.validateRequest()
+    middlewareInstance.CORS(),
+    middlewareInstance.validateRequest()
   );
 
   // Add custom middleware
@@ -115,7 +115,7 @@ middlewareInstance.init(path.join(__dirname, 'PetStore.yaml'), err => {
 
   // The mock middleware will use our custom data store,
   // which we already pre-populated with mock data
-  app.use(...middlewareInstance.mock(myDB));
+  app.use(middlewareInstance.mock(myDB));
 
   // Add a custom error handler that returns errors as HTML
   app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {


### PR DESCRIPTION
While using these typings I got a lot of errors like this when running `tcs` (using TypeScript 1.8.9):

> error TS2322: Type 'RequestHandler[]' is not assignable to type 'RequestHandler'

Express expects multiple `RequestHandler` instances because of the spread operator in `use(...handler: RequestHandler[]): T;`, and not an array of RequestHandlers
