### PR TITLE
Fix typing for Resource.parse

### DIFF
--- a/swagger-express-middleware.d.ts
+++ b/swagger-express-middleware.d.ts
@@ -339,7 +339,7 @@ declare namespace middleware {
      * If the JSON is invalid, then an error will be thrown.
      * If the JSON is a single object, then a single Resource will be returned; otherwise, an array of Resource objects will be returned.
      */
-    static parse(json: string): Resource;
+    static parse(json: any): Resource|Resource[];
   }
 
   /**


### PR DESCRIPTION
According the the docblock and actual implementation in the middleware, `Resource.parse` accepts either a string or a plain old object (i.e. `any`) and can also return an array of `Resource` objects, not only a single one.
